### PR TITLE
Improve Mac and Mac Catalyst window resizing

### DIFF
--- a/Sources/Grid/Grid.swift
+++ b/Sources/Grid/Grid.swift
@@ -31,7 +31,9 @@ public struct Grid<Content>: View where Content: View {
             alignment: .topLeading
         )
         .onPreferenceChange(GridPreferencesKey.self) { preferences in
-            self.preferences = preferences
+            DispatchQueue.main.async {
+                self.preferences = preferences
+            }
         }
     }
 }


### PR DESCRIPTION
Hi!

I've noticed, that when trying to use Grid in MacOS or in Mac Catalyst app with not-fixed window size, resizing causes massive lags to the app, because preferences are updated very often, and SwiftUI drawing engine just cannot manage such frequent updates. 

This PR suggests dispatching preference changes asynchronously to improve rendering in such cases. The solution is not perfect, because it causes UI to update a little bit later then before, but perfomance of the app is hugely improved. This can be verified by running Mac demo app and trying to resize a window before and after this PR.